### PR TITLE
orders: check changed products from PackageCreated

### DIFF
--- a/orders/template.yaml
+++ b/orders/template.yaml
@@ -217,14 +217,17 @@ Resources:
         - Version: "2012-10-17"
           Statement:
             - Effect: Allow
-              Action: dynamodb:UpdateItem
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
               Resource:
                 - !GetAtt Table.Arn
               Condition:
-                # Scope down to only allow changing the status
+                # Scope down to only allow fetching/changing the status and products
                 ForAllValues:StringEquals:
                   dynamodb:Attributes:
                     - orderId
+                    - products
                     - status
 
   OnEventsLogGroup:

--- a/orders/tests/integ/test_on_events.py
+++ b/orders/tests/integ/test_on_events.py
@@ -1,9 +1,10 @@
+import copy
 import datetime
 import json
 import time
 import boto3
 import pytest
-from fixtures import get_order, get_product # pylint: disable=import-error
+from fixtures import listener, get_order, get_product # pylint: disable=import-error
 from helpers import get_parameter # pylint: disable=import-error,no-name-in-module
 
 
@@ -30,7 +31,7 @@ def order(get_order):
     return get_order()
 
 
-def test_on_package_created(order, table_name, event_bus_name):
+def test_on_package_created(order, listener, table_name, event_bus_name):
     """
     Test OnEvents function on a PackageCreated event
     """
@@ -61,11 +62,77 @@ def test_on_package_created(order, table_name, event_bus_name):
     assert "status" in response["Item"]
     assert response["Item"]["status"] == "PACKAGED"
 
+    # Check events
+    messages = listener("orders", 5)
+    found = False
+    for message in messages:
+        print("MESSAGE RECEIVED:", message)
+        body = json.loads(message["Body"])
+        if order["orderId"] in body["resources"] and body["detail-type"] == "OrderModified":
+            found = True
+            assert "status" in body["detail"]["changed"]
+            assert "products" not in body["detail"]["changed"]
+            assert body["detail"]["new"]["status"] == "PACKAGED"
+    assert found == True
+
     # Clean up
     table.delete_item(Key={"orderId": order["orderId"]})
 
 
-def test_on_packaging_failed(order, table_name, event_bus_name):
+def test_on_package_created_products(order, listener, table_name, event_bus_name):
+    """
+    Test OnEvents function on a PackageCreated event when there are less products
+    """
+
+    eventbridge = boto3.client("events")
+    table = boto3.resource("dynamodb").Table(table_name) # pylint: disable=no-member
+
+    # Store order in DynamoDB table
+    table.put_item(Item=order)
+
+    package_order = copy.deepcopy(order)
+    removed_product = package_order["products"].pop(0)
+
+    # Create the event
+    event = {
+        "Time": datetime.datetime.now(),
+        "Source": "ecommerce.warehouse",
+        "DetailType": "PackageCreated",
+        "Resources": [order["orderId"]],
+        "Detail": json.dumps(package_order),
+        "EventBusName": event_bus_name
+    }
+    eventbridge.put_events(Entries=[event])
+
+    # Wait
+    time.sleep(5)
+
+    # Check the DynamoDB table
+    response = table.get_item(Key={"orderId": order["orderId"]})
+    assert "Item" in response
+    assert "status" in response["Item"]
+    assert response["Item"]["status"] == "PACKAGED"
+    assert len(response["Item"]["products"]) == len(package_order["products"])
+    assert removed_product["productId"] not in [p["productId"] for p in response["Item"]["products"]]
+
+    # Check events
+    messages = listener("orders", 5)
+    found = False
+    for message in messages:
+        print("MESSAGE RECEIVED:", message)
+        body = json.loads(message["Body"])
+        if order["orderId"] in body["resources"] and body["detail-type"] == "OrderModified":
+            found = True
+            assert "status" in body["detail"]["changed"]
+            assert "products" in body["detail"]["changed"]
+            assert body["detail"]["new"]["status"] == "PACKAGED"
+    assert found == True
+
+    # Clean up
+    table.delete_item(Key={"orderId": order["orderId"]})
+
+
+def test_on_packaging_failed(order, listener, table_name, event_bus_name):
     """
     Test OnEvents function on a PackagingFailed event
     """
@@ -96,11 +163,23 @@ def test_on_packaging_failed(order, table_name, event_bus_name):
     assert "status" in response["Item"]
     assert response["Item"]["status"] == "PACKAGING_FAILED"
 
+    # Check events
+    messages = listener("orders", 5)
+    found = False
+    for message in messages:
+        print("MESSAGE RECEIVED:", message)
+        body = json.loads(message["Body"])
+        if order["orderId"] in body["resources"] and body["detail-type"] == "OrderModified":
+            found = True
+            assert "status" in body["detail"]["changed"]
+            assert body["detail"]["new"]["status"] == "PACKAGING_FAILED"
+    assert found == True
+
     # Clean up
     table.delete_item(Key={"orderId": order["orderId"]})
 
 
-def test_on_delivery_completed(order, table_name, event_bus_name):
+def test_on_delivery_completed(order, listener, table_name, event_bus_name):
     """
     Test OnEvents function on a DeliveryCompleted event
     """
@@ -131,11 +210,23 @@ def test_on_delivery_completed(order, table_name, event_bus_name):
     assert "status" in response["Item"]
     assert response["Item"]["status"] == "FULFILLED"
 
+    # Check events
+    messages = listener("orders", 5)
+    found = False
+    for message in messages:
+        print("MESSAGE RECEIVED:", message)
+        body = json.loads(message["Body"])
+        if order["orderId"] in body["resources"] and body["detail-type"] == "OrderModified":
+            found = True
+            assert "status" in body["detail"]["changed"]
+            assert body["detail"]["new"]["status"] == "FULFILLED"
+    assert found == True
+
     # Clean up
     table.delete_item(Key={"orderId": order["orderId"]})
 
 
-def test_on_delivery_failed(order, table_name, event_bus_name):
+def test_on_delivery_failed(order, listener, table_name, event_bus_name):
     """
     Test OnEvents function on a DeliveryFailed event
     """
@@ -165,6 +256,18 @@ def test_on_delivery_failed(order, table_name, event_bus_name):
     assert "Item" in response
     assert "status" in response["Item"]
     assert response["Item"]["status"] == "DELIVERY_FAILED"
+
+    # Check events
+    messages = listener("orders", 5)
+    found = False
+    for message in messages:
+        print("MESSAGE RECEIVED:", message)
+        body = json.loads(message["Body"])
+        if order["orderId"] in body["resources"] and body["detail-type"] == "OrderModified":
+            found = True
+            assert "status" in body["detail"]["changed"]
+            assert body["detail"]["new"]["status"] == "DELIVERY_FAILED"
+    assert found == True
 
     # Clean up
     table.delete_item(Key={"orderId": order["orderId"]})

--- a/orders/tests/unit/test_on_events.py
+++ b/orders/tests/unit/test_on_events.py
@@ -1,7 +1,7 @@
 from boto3.dynamodb.types import TypeSerializer
 from botocore import stub
 import pytest
-from fixtures import context, lambda_module # pylint: disable=import-error
+from fixtures import context, lambda_module, get_order, get_product # pylint: disable=import-error
 
 lambda_module = pytest.fixture(scope="module", params=[{
     "function_dir": "on_events",
@@ -15,9 +15,14 @@ lambda_module = pytest.fixture(scope="module", params=[{
 context = pytest.fixture(context)
 
 
-def test_set_status(lambda_module):
+@pytest.fixture
+def order(get_order):
+    return get_order()
+
+
+def test_update_order(lambda_module):
     """
-    test set_status()
+    test update_order()
     """
 
     order_id = "ORDER_ID"
@@ -28,7 +33,9 @@ def test_set_status(lambda_module):
         "TableName": "TABLE_NAME",
         "Key": {"orderId": order_id},
         "UpdateExpression": stub.ANY,
-        "ExpressionAttributeNames": stub.ANY,
+        "ExpressionAttributeNames": {
+            "#s": "status"
+        },
         "ExpressionAttributeValues": {
             ":s": status
         }
@@ -36,13 +43,59 @@ def test_set_status(lambda_module):
     table.add_response("update_item", {}, expected_params)
     table.activate()
 
-    lambda_module.set_status(order_id, status)
+    lambda_module.update_order(order_id, status)
 
     table.assert_no_pending_responses()
     table.deactivate()
 
 
-def test_handler_fulfilled(monkeypatch, lambda_module, context):
+def test_update_order_products(lambda_module, order):
+    """
+    test update_order() with products
+    """
+
+    order_id = "ORDER_ID"
+    status = "STATUS"
+
+    table = stub.Stubber(lambda_module.table.meta.client)
+    # get_item stub
+    expected_params = {
+        "TableName": "TABLE_NAME",
+        "Key": {"orderId": order_id},
+        "AttributesToGet": ["products"]
+    }
+    response = {
+        "Item": {
+            k: TypeSerializer().serialize(v)
+            for k, v in order.items()
+        }
+    }
+    print(response)
+    table.add_response("get_item", response, expected_params)
+    # update_item stub
+    expected_params = {
+        "TableName": "TABLE_NAME",
+        "Key": {"orderId": order_id},
+        "UpdateExpression": stub.ANY,
+        "ExpressionAttributeNames": {
+            "#s": "status",
+            "#p": "products"
+        },
+        "ExpressionAttributeValues": {
+            ":p": order["products"],
+            ":s": status
+        }
+    }
+    table.add_response("update_item", {}, expected_params)
+    table.activate()
+
+    lambda_module.update_order(order_id, status, order["products"])
+
+    table.assert_no_pending_responses()
+    table.deactivate()
+
+
+def test_handler(monkeypatch, lambda_module, context, order):
     """
     Test handler()
     """
@@ -61,7 +114,8 @@ def test_handler_fulfilled(monkeypatch, lambda_module, context):
         "status": "PACKAGED",
         "source": "ecommerce.warehouse",
         "detail-type": "PackageCreated",
-        "called": True
+        "called": True,
+        "products": True
     }, {
         "status": "PACKAGING_FAILED",
         "source": "ecommerce.warehouse",
@@ -85,15 +139,18 @@ def test_handler_fulfilled(monkeypatch, lambda_module, context):
     }]
 
     for test_case in test_cases:
-        def set_status(order_id: str, status: str) -> None:
+        def update_order(order_id: str, status: str, products=None) -> None:
             assert test_case["called"]
             assert order_id == "ORDER_ID"
             assert status == test_case["status"]
-        monkeypatch.setattr(lambda_module, "set_status", set_status)
+            if test_case.get("products", False):
+                assert products is not None
+        monkeypatch.setattr(lambda_module, "update_order", update_order)
 
         event = {
             "resources": ["ORDER_ID"],
             "source": test_case["source"],
-            "detail-type": test_case["detail-type"]
+            "detail-type": test_case["detail-type"],
+            "detail": order
         }
         lambda_module.handler(event, context)


### PR DESCRIPTION
When the OnEvents function receives a PackageCreated event, it now
updates products in the order. This causes the TableUpdate function to
trigger an event that contains "products" in the "changed" field in the
detail.

This commits also updates the on_events integration tests to check if
events trigger a new OrderModified event.

*Issue #, if available:* https://github.com/aws-samples/aws-serverless-ecommerce-platform/issues/57 https://github.com/aws-samples/aws-serverless-ecommerce-platform/issues/56

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
