### PR TITLE
payment-3p: fix Makefile so it doesnt depend on local typescript

### DIFF
--- a/payment-3p/Makefile
+++ b/payment-3p/Makefile
@@ -18,7 +18,6 @@ build: _install
 		mkdir build/ ; \
 	fi
 	cp -rp src/ build/src/
-	npm i
 	npx cdk synth --verbose > build/template.yaml
 
 	# Install packages and transpile to Javascript for each Lambda function

--- a/payment-3p/Makefile
+++ b/payment-3p/Makefile
@@ -18,14 +18,15 @@ build: _install
 		mkdir build/ ; \
 	fi
 	cp -rp src/ build/src/
+	npm i
 	npx cdk synth --verbose > build/template.yaml
 
 	# Install packages and transpile to Javascript for each Lambda function
 	for function_folder in build/src/* ; do \
 		cd $$function_folder ; \
 		npm i ; \
-		npx tsc -p . ; \
 		cd ${CURDIR} ; \
+		npx tsc -p $$function_folder ; \
 	done
 
 	# Package artifacts


### PR DESCRIPTION

*Issue #, if available:* 82

*Description of changes:* Change the Makefile for the payment-3p service to use the locally installed typescript binary instead of falling back on the global environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
