### PR TITLE
tests: fix cognito sending emails

### DIFF
--- a/frontend-api/tests/integ/test_graphql.py
+++ b/frontend-api/tests/integ/test_graphql.py
@@ -141,7 +141,8 @@ def user_id(user_pool_id, email, password):
         UserAttributes=[{
             "Name": "email",
             "Value": email
-        }]
+        }],
+        MessageAction="SUPPRESS"
     )
     user_id = response["User"]["Username"]
     cognito.admin_set_user_password(

--- a/frontend-api/tests/integ/test_graphql_admin.py
+++ b/frontend-api/tests/integ/test_graphql_admin.py
@@ -120,7 +120,8 @@ def user_id(user_pool_id, email, password):
         UserAttributes=[{
             "Name": "email",
             "Value": email
-        }]
+        }],
+        MessageAction="SUPPRESS"
     )
     user_id = response["User"]["Username"]
     cognito.admin_set_user_password(

--- a/shared/tests/e2e/test_happy_path.py
+++ b/shared/tests/e2e/test_happy_path.py
@@ -106,7 +106,8 @@ def user_id(user_pool_id, email, password):
         UserAttributes=[{
             "Name": "email",
             "Value": email
-        }]
+        }],
+        MessageAction="SUPPRESS"
     )
     user_id = response["User"]["Username"]
     cognito.admin_set_user_password(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Before this change, Cognito would send emails to non-existing email
addresses when performing admin_create_user in integration tests. This
increases the bounce rate for Cognito, which could result in reduction
in the email send quota from Cognito.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
