### PR TITLE
Fix DeprecationWarning in dependency

### DIFF
--- a/delivery-pricing/src/pricing/main.py
+++ b/delivery-pricing/src/pricing/main.py
@@ -8,14 +8,14 @@ import math
 from typing import List
 import os
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 from ecom.apigateway import iam_user_id, response # pylint: disable=import-error
 
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
 
 
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -75,7 +75,7 @@ def get_pricing(products: List[dict], address: dict) -> int:
     return count_boxes([p["package"] for p in products]) * get_shipping_cost(address)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/delivery-pricing/src/pricing/requirements.txt
+++ b/delivery-pricing/src/pricing/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 ../shared/src/ecom/

--- a/delivery/src/on_package_created/main.py
+++ b/delivery/src/on_package_created/main.py
@@ -10,7 +10,7 @@ import boto3
 import requests # pylint: disable=import-error
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth # pylint: disable=import-error
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
@@ -20,7 +20,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -92,7 +92,7 @@ def save_shipping_request(order: dict) -> None:
     })
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, context):
     """

--- a/delivery/src/on_package_created/requirements.txt
+++ b/delivery/src/on_package_created/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 aws_requests_auth
 boto3
 requests

--- a/delivery/src/table_update/main.py
+++ b/delivery/src/table_update/main.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 from ecom.helpers import Encoder
 
 
@@ -20,7 +20,7 @@ EVENT_BUS_NAME = os.environ["EVENT_BUS_NAME"]
 
 eventbridge = boto3.client("events") # pylint: disable=invalid-name
 deserialize = TypeDeserializer().deserialize # pylint: disable=invalid-name
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -115,7 +115,7 @@ def process_record(record: dict) -> Optional[dict]:
         raise ValueError("Wrong eventName value for DynamoDB event: {}".format(record["eventName"]))
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/delivery/src/table_update/requirements.txt
+++ b/delivery/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/docs/function_code.md
+++ b/docs/function_code.md
@@ -117,17 +117,17 @@ In your function code, you can then add the following to set up the logger and t
 
 ```python
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 
 
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 ```
 
 You can then decorate your function handler as such:
 
 ```python
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/orders/src/create_order/main.py
+++ b/orders/src/create_order/main.py
@@ -15,7 +15,7 @@ import jsonschema
 import requests
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
@@ -27,7 +27,7 @@ PRODUCTS_API_URL = os.environ["PRODUCTS_API_URL"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -190,7 +190,7 @@ def store_order(order: dict) -> None:
     table.put_item(Item=order)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/orders/src/create_order/requirements.txt
+++ b/orders/src/create_order/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 aws_requests_auth
 boto3
 jsonschema==3.2.0

--- a/orders/src/get_order/main.py
+++ b/orders/src/get_order/main.py
@@ -7,7 +7,7 @@ import os
 from typing import Optional
 import boto3
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 from ecom.apigateway import iam_user_id, response # pylint: disable=import-error
 
 
@@ -17,7 +17,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -46,7 +46,7 @@ def get_order(order_id: str) -> Optional[dict]:
     return order
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/orders/src/get_order/requirements.txt
+++ b/orders/src/get_order/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/orders/src/on_events/main.py
+++ b/orders/src/on_events/main.py
@@ -9,7 +9,7 @@ import os
 from typing import List, Optional, Union
 import boto3
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
@@ -18,7 +18,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -97,7 +97,7 @@ def update_order(order_id: str, status: str, products: Optional[List[dict]] = No
     )
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/orders/src/on_events/requirements.txt
+++ b/orders/src/on_events/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3

--- a/orders/src/table_update/main.py
+++ b/orders/src/table_update/main.py
@@ -8,7 +8,7 @@ from typing import List
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 from ecom.eventbridge import ddb_to_event # pylint: disable=import-error
 
 
@@ -18,7 +18,7 @@ EVENT_BUS_NAME = os.environ["EVENT_BUS_NAME"]
 
 eventbridge = boto3.client("events") # pylint: disable=invalid-name
 type_deserializer = TypeDeserializer() # pylint: disable=invalid-name
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -32,7 +32,7 @@ def send_events(events: List[dict]):
     eventbridge.put_events(Entries=events)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/orders/src/table_update/requirements.txt
+++ b/orders/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/payment/src/on_completed/main.py
+++ b/payment/src/on_completed/main.py
@@ -7,7 +7,7 @@ import os
 import boto3
 import requests
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 API_URL = os.environ["API_URL"]
@@ -17,7 +17,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -59,7 +59,7 @@ def process_payment(payment_token: str) -> None:
         raise Exception("Failed to process payment: {}".format(response.json().get("message", "No error message")))
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/payment/src/on_completed/requirements.txt
+++ b/payment/src/on_completed/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 requests
 ../shared/src/ecom/

--- a/payment/src/on_created/main.py
+++ b/payment/src/on_created/main.py
@@ -6,7 +6,7 @@ OnCreated Function
 import os
 import boto3
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
@@ -15,7 +15,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -31,7 +31,7 @@ def save_payment_token(order_id: str, payment_token: str) -> None:
     })
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/payment/src/on_created/requirements.txt
+++ b/payment/src/on_created/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/payment/src/on_failed/main.py
+++ b/payment/src/on_failed/main.py
@@ -7,7 +7,7 @@ import os
 import boto3
 import requests
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 API_URL = os.environ["API_URL"]
@@ -17,7 +17,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -59,7 +59,7 @@ def cancel_payment(payment_token: str) -> None:
         raise Exception("Failed to process payment: {}".format(response.json().get("message", "No error message")))
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/payment/src/on_failed/requirements.txt
+++ b/payment/src/on_failed/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 requests
 ../shared/src/ecom/

--- a/payment/src/on_modified/main.py
+++ b/payment/src/on_modified/main.py
@@ -7,7 +7,7 @@ import os
 import boto3
 import requests
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 API_URL = os.environ["API_URL"]
@@ -17,7 +17,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -50,7 +50,7 @@ def update_payment_amount(payment_token: str, amount: int) -> None:
         raise Exception("Error updating amount: {}".format(body["message"]))
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/payment/src/on_modified/requirements.txt
+++ b/payment/src/on_modified/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 requests
 ../shared/src/ecom/

--- a/payment/src/validate/main.py
+++ b/payment/src/validate/main.py
@@ -6,7 +6,7 @@ import json
 import os
 import requests
 from aws_lambda_powertools.tracing import Tracer #pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context #pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger #pylint: disable=import-error
 from ecom.apigateway import iam_user_id, response # pylint: disable=import-error
 
 
@@ -14,7 +14,7 @@ API_URL = os.environ["API_URL"]
 ENVIRONMENT = os.environ["ENVIRONMENT"]
 
 
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -40,7 +40,7 @@ def validate_payment_token(payment_token: str, total: int) -> bool:
     return body.get("ok", False)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/payment/src/validate/requirements.txt
+++ b/payment/src/validate/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 requests
 ../shared/src/ecom/

--- a/products/src/table_update/main.py
+++ b/products/src/table_update/main.py
@@ -8,7 +8,7 @@ from typing import List
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 from ecom.eventbridge import ddb_to_event # pylint: disable=import-error
 
 
@@ -18,7 +18,7 @@ EVENT_BUS_NAME = os.environ["EVENT_BUS_NAME"]
 
 eventbridge = boto3.client("events") # pylint: disable=invalid-name
 type_deserializer = TypeDeserializer() # pylint: disable=invalid-name
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -32,7 +32,7 @@ def send_events(events: List[dict]):
     eventbridge.put_events(Entries=events)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/products/src/table_update/requirements.txt
+++ b/products/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/products/src/validate/main.py
+++ b/products/src/validate/main.py
@@ -8,7 +8,7 @@ import os
 from typing import List, Optional, Union, Set
 import boto3
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 from ecom.apigateway import iam_user_id, response # pylint: disable=import-error
 
 
@@ -16,7 +16,7 @@ ENVIRONMENT = os.environ["ENVIRONMENT"]
 TABLE_NAME = os.environ["TABLE_NAME"]
 
 
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 table = boto3.resource("dynamodb").Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
 tracer = Tracer() # pylint: disable=invalid-name
 
@@ -90,7 +90,7 @@ def validate_products(products: List[dict]) -> Set[Union[List[dict], str]]:
     return validated_products, ". ".join(reasons)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/products/src/validate/requirements.txt
+++ b/products/src/validate/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/shared/tests/unit/coveragerc
+++ b/shared/tests/unit/coveragerc
@@ -5,6 +5,7 @@ branch = True
 # Omit dependencies
 omit = 
     */build/src/*/six.py
+    */build/src/*/zipp.py
     */build/src/*/*/*
 show_missing = True
 fail_under = 90

--- a/users/src/sign_up/main.py
+++ b/users/src/sign_up/main.py
@@ -7,7 +7,7 @@ import datetime
 import json
 import os
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 import boto3
 
 
@@ -16,7 +16,7 @@ EVENT_BUS_NAME = os.environ["EVENT_BUS_NAME"]
 
 
 eventbridge = boto3.client("events") # pylint: disable=invalid-name
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -50,7 +50,7 @@ def send_event(event: dict):
     eventbridge.put_events(Entries=[event])
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/users/src/sign_up/requirements.txt
+++ b/users/src/sign_up/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3

--- a/warehouse/src/on_order_events/main.py
+++ b/warehouse/src/on_order_events/main.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 import boto3
 from boto3.dynamodb.conditions import Key
 from aws_lambda_powertools.tracing import Tracer # pylint: disable=import-error
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context # pylint: disable=import-error
+from aws_lambda_powertools.logging.logger import Logger # pylint: disable=import-error
 
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
@@ -18,7 +18,7 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 
 dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -333,7 +333,7 @@ def on_order_deleted(order: dict):
     delete_metadata(order_id)
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/warehouse/src/on_order_events/requirements.txt
+++ b/warehouse/src/on_order_events/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/

--- a/warehouse/src/table_update/main.py
+++ b/warehouse/src/table_update/main.py
@@ -8,7 +8,7 @@ import json
 import os
 from typing import List, Optional
 from aws_lambda_powertools.tracing import Tracer
-from aws_lambda_powertools.logging import logger_setup, logger_inject_lambda_context
+from aws_lambda_powertools.logging.logger import Logger
 import boto3
 from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import TypeDeserializer
@@ -25,7 +25,7 @@ dynamodb = boto3.resource("dynamodb") # pylint: disable=invalid-name
 eventbridge = boto3.client("events") # pylint: disable=invalid-name
 table = dynamodb.Table(TABLE_NAME) # pylint: disable=invalid-name,no-member
 type_deserializer = TypeDeserializer() # pylint: disable=invalid-name
-logger = logger_setup() # pylint: disable=invalid-name
+logger = Logger() # pylint: disable=invalid-name
 tracer = Tracer() # pylint: disable=invalid-name
 
 
@@ -116,7 +116,7 @@ def get_products(order_id: str) -> List[dict]:
     return products
 
 
-@logger_inject_lambda_context
+@logger.inject_lambda_context
 @tracer.capture_lambda_handler
 def handler(event, _):
     """

--- a/warehouse/src/table_update/requirements.txt
+++ b/warehouse/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools>=0.3.1
+aws-lambda-powertools==0.9.3
 boto3
 ../shared/src/ecom/


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:* aws-lambda-power-tools deprecated the function logger_setup. Updates to use Logger class instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
