### PR TITLE
fix: malformed log statement in orders service

### DIFF
--- a/orders/src/on_events/main.py
+++ b/orders/src/on_events/main.py
@@ -108,7 +108,7 @@ def handler(event, _):
 
     for order_id in order_ids:
         logger.info({
-            "message": "Got event of type {} from {} for order {}".format(order_id, event["source"], event["resources"]),
+            "message": "Got event of type {} from {} for order {}".format(event["detail-type"], event["source"], order_id),
             "source": event["source"],
             "eventType": event["detail-type"],
             "orderId": order_id


### PR DESCRIPTION
*Description of changes:*
Fix for potentially incorrect log statement:

Line 111 originally:
```python
"Got event of type {} from {} for order {}".format(order_id, event["source"], event["resources"])
```
Amended to:
```python
"Got event of type {} from {} for order {}".format(event["detail-type"], event["source"], order_id)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.