### PR TITLE
tools: automatically create an S3 bucket for artifacts

### DIFF
--- a/docs/common_issues.md
+++ b/docs/common_issues.md
@@ -1,12 +1,5 @@
 # Common issues
 
-## During the packaging step, I get an error that the S3 bucket does not exist or an access denied error.
-
-To package the artifacts, you need to have an S3 bucket with write access and within the same AWS region as where you want to deploy this project.
-
-1. Create or ensure that you have an S3 bucket with write access that you can use to store artifacts (Lambda function code packages, CloudFormation templates, etc.).
-2. Set the environment variable `S3_BUCKET` to that bucket name: `export S3_BUCKET=replace-me-with-your-bucket-name`
-
 ## I get an error "ModuleNotFoundError: No module named '_ctypes'".
 
 If you are using Linux, you are probably missing the libffi-dev package on your system. You need to install that package using your distribution's package manager. For example `sudo apt-get install libffi-dev` or `sudo yum install libffi-dev`, then re-run `make setup`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,7 +13,7 @@ You will also need [Node](https://nodejs.org/en/) version 12 or greater, [jq](ht
 
 ## Deploy the infrastructure on AWS
 
-If you want to deploy the entire project into your AWS account in a dev environment, you can run the command `make all` in the [root](../) of this project. Please note that you will need to have an S3 bucket with write access to store artifacts as part of the packaging step. You will then need to set the environment variable S3_BUCKET to the bucket name, for example: `export S3_BUCKET=my-artifact-bucket`.
+If you want to deploy the entire project into your AWS account in a dev environment, you can run the command `make all` in the [root](../) of this project. Please note that this will create an S3 bucket to store artifacts as part of the packaging step.
 
 If you want to deploy only a specific service and its dependencies, you can use the command `make deps-${SERVICE}`.
 

--- a/docs/make_targets.md
+++ b/docs/make_targets.md
@@ -35,4 +35,3 @@ These targets should be defined in the Makefile of each individual service. You 
 You can tweak some of the behaviour by using the following environment variables.
 
 * __ENVIRONMENT__: The target environment on AWS on which you want to deploy resources or run integration tests. This default to `dev`.
-* __S3_BUCKET__: The S3 bucket used to store artifacts as part of the `package` target. This defaults to `${USER}-src`. You need to have permission to write to that S3 bucket or the package command will fail.

--- a/tools/package
+++ b/tools/package
@@ -44,9 +44,18 @@ trap cleanup EXIT
 
 package_cloudformation () {
     if [ -f $service_dir/build/template.yaml ]; then
+        # Construct the S3 Bucket name
+        aws_region=$(python3 -c 'import boto3; print(boto3.Session().region_name)')
+        aws_account_id=$(aws sts get-caller-identity | jq .Account -r)
+        s3_bucket="ecommerce-artifacts-${aws_account_id}-${aws_region}"
+        # Create the S3 bucket if it doesn't exist
+        aws s3api head-bucket --bucket $s3_bucket || {
+            aws s3 mb s3://$s3_bucket --region ${aws_region}
+        }
+
         pushd $build_dir
         aws cloudformation package \
-            --s3-bucket ${S3_BUCKET:-${USER}-src} \
+            --s3-bucket $s3_bucket \
             --s3-prefix "artifacts" \
             --template-file template.yaml \
             --output-template-file template.out || {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Before this, users had to manually create an S3 bucket for artifacts (Lambda function code, etc.). Now, the `tools/package` script creates an S3 bucket named `ecommerce-artifacts-ACCOUNT_ID-REGION` for artifacts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
