### PR TITLE
chore: bump aws-lambda-powertools to 1.6.1

### DIFF
--- a/delivery-pricing/src/pricing/requirements.txt
+++ b/delivery-pricing/src/pricing/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 ../shared/src/ecom/

--- a/delivery/src/on_package_created/requirements.txt
+++ b/delivery/src/on_package_created/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 aws_requests_auth
 boto3
 requests

--- a/delivery/src/table_update/requirements.txt
+++ b/delivery/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/orders/src/create_order/requirements.txt
+++ b/orders/src/create_order/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 aws_requests_auth
 boto3
 jsonschema==3.2.0

--- a/orders/src/get_order/requirements.txt
+++ b/orders/src/get_order/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/orders/src/on_events/requirements.txt
+++ b/orders/src/on_events/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3

--- a/orders/src/table_update/requirements.txt
+++ b/orders/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/payment/src/on_completed/requirements.txt
+++ b/payment/src/on_completed/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 requests
 ../shared/src/ecom/

--- a/payment/src/on_created/requirements.txt
+++ b/payment/src/on_created/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/payment/src/on_failed/requirements.txt
+++ b/payment/src/on_failed/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 requests
 ../shared/src/ecom/

--- a/payment/src/on_modified/requirements.txt
+++ b/payment/src/on_modified/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 requests
 ../shared/src/ecom/

--- a/payment/src/validate/requirements.txt
+++ b/payment/src/validate/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 requests
 ../shared/src/ecom/

--- a/platform/src/on_connect/requirements.txt
+++ b/platform/src/on_connect/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/platform/src/on_disconnect/requirements.txt
+++ b/platform/src/on_disconnect/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/platform/src/on_events/requirements.txt
+++ b/platform/src/on_events/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3

--- a/platform/src/register/requirements.txt
+++ b/platform/src/register/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/products/src/table_update/requirements.txt
+++ b/products/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/products/src/validate/requirements.txt
+++ b/products/src/validate/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/users/src/sign_up/requirements.txt
+++ b/users/src/sign_up/requirements.txt
@@ -1,2 +1,2 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3

--- a/warehouse/src/on_order_events/requirements.txt
+++ b/warehouse/src/on_order_events/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==0.9.3
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/

--- a/warehouse/src/table_update/requirements.txt
+++ b/warehouse/src/table_update/requirements.txt
@@ -1,3 +1,3 @@
-aws-lambda-powertools==1.0.1
+aws-lambda-powertools==1.6.1
 boto3
 ../shared/src/ecom/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* bumping aws-lambda-powertools to 1.6.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
