### PR TITLE
Fix speccy usage - Add lint command

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -71,7 +71,7 @@ lint_python3 () {
 
 lint_openapi () {
     if [ -f $service_dir/resources/openapi.yaml ]; then
-        speccy --config $ROOT/shared/lint/speccy.yaml \
+        speccy lint --config $ROOT/shared/lint/speccy.yaml \
             $service_dir/resources/openapi.yaml
     fi
 }


### PR DESCRIPTION
*Issue #, if available:* #199 

*Description of changes:* Added _lint_ command in lint_openapi() method. Valid usage in [current documentation](https://github.com/wework/speccy#usage) is `speccy lint` .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
